### PR TITLE
Pass in cluster to create Cassandra

### DIFF
--- a/metrics-cassandra/src/main/java/com/codahale/metrics/cassandra/Cassandra.java
+++ b/metrics-cassandra/src/main/java/com/codahale/metrics/cassandra/Cassandra.java
@@ -90,28 +90,28 @@ public class Cassandra implements Closeable {
     for (String address : addresses) {
       builder.addContactPoint(address);
     }
-	builder
-	  .withPort(port)
-	  .withCompression(Compression.LZ4)
-	  .withRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE)
-	  .withLoadBalancingPolicy(LatencyAwarePolicy.builder(new RoundRobinPolicy()).build());
-	
-	Cluster cluster = builder.build();
-	
-	try {
-	  // Attempt to init the cluster to make sure it's usable. I'd prefer to remove this and leave it on the
-	  // client to retry when the connect method throws an exception.
-	  cluster.init();
-	  return cluster;
-	} catch(NoHostAvailableException e)	{
-	  LOGGER.warn("Unable to connect to Cassandra, will retry contact points next time",
-	      cluster, e);
+    builder
+      .withPort(port)
+      .withCompression(Compression.LZ4)
+      .withRetryPolicy(DowngradingConsistencyRetryPolicy.INSTANCE)
+      .withLoadBalancingPolicy(LatencyAwarePolicy.builder(new RoundRobinPolicy()).build());
+    
+    Cluster cluster = builder.build();
+    
+    try {
+      // Attempt to init the cluster to make sure it's usable. I'd prefer to remove this and leave it on the
+      // client to retry when the connect method throws an exception.
+      cluster.init();
+      return cluster;
+    } catch(NoHostAvailableException e) {
+      LOGGER.warn("Unable to connect to Cassandra, will retry contact points next time",
+          cluster, e);
       cluster = builder.build();
-	  cluster.init();
-	}
-	
-	return cluster;
-	
+      cluster.init();
+    }
+    
+    return cluster;
+    
   }
 
   /**


### PR DESCRIPTION
Allow a cluster to be passed in when creating the Cassandra object. This allows users to specify a lot of other options (authentication, compression, etc) outside of the metrics-cassandra library. Move reconnect attempts into creation of cluster. I debated creating two static factory methods that could call the came constructor but went this route to maintain backwards compatibility. 
